### PR TITLE
The `each` operator takes an array and returns an array

### DIFF
--- a/src/operators/each.ts
+++ b/src/operators/each.ts
@@ -1,7 +1,7 @@
 import { Validator, putPath } from "../Validator";
 import { Problem } from "../types";
 
-export function each<T, R>(validator: Validator<T, R>): Validator<T, R[]> {
+export function each<T, R>(validator: Validator<T, R>): Validator<T[], R[]> {
   return new Validator(async input => {
     if (!Array.isArray(input)) {
       return Validator.reject("Expected an array");

--- a/test/operators/each.test.ts
+++ b/test/operators/each.test.ts
@@ -18,6 +18,7 @@ describe("each", () => {
   });
 
   it("produces an error when not given an array", async () => {
+    // @ts-expect-error
     expect(await validator.validate(1)).toEqual({
       valid: false,
       errors: [{ message: "Expected an array", path: [] }]


### PR DESCRIPTION
This is a bugfix for v0.4.0. The input type needs to be an array.